### PR TITLE
Revert "Simplify privileged container"

### DIFF
--- a/Dockerfile.privileged
+++ b/Dockerfile.privileged
@@ -2,9 +2,12 @@ FROM alpine
 MAINTAINER Pratik Mallya <mallya@us.ibm.com>
 WORKDIR /root
 
-RUN apk update && apk add openssh
+RUN apk update && apk add \
+  openssh \
+  ansible
 
-CMD mkdir -p /host/root/.ssh && \
-    echo -e  'y\n'| ssh-keygen -Nq '' -f /root/.ssh/id_rsa && \
-    cat /root/.ssh/id_rsa.pub >> /host/root/.ssh/authorized_keys && \
-    ssh localhost
+RUN echo "ssh-keygen -N '' -f /root/.ssh/id_rsa" >> ssh_node.sh
+RUN echo "mkdir -p /host/root/.ssh"
+RUN echo "cat /root/.ssh/id_rsa.pub >> /host/root/.ssh/authorized_keys" >> ssh_node.sh
+RUN echo "ssh localhost" >> ssh_node.sh
+RUN chmod +x ssh_node.sh


### PR DESCRIPTION
Reverts pratikmallya/Dockerfiles#6

kubectl exec does not provide option to run entrypoint. We need the script back